### PR TITLE
Encapsulate backend URL in a backend-url-providing service

### DIFF
--- a/RevSpaceWebApp/src/app/services/backend.service.spec.ts
+++ b/RevSpaceWebApp/src/app/services/backend.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { BackendService } from './backend.service';
+
+describe('BackendService', () => {
+  let service: BackendService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(BackendService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/RevSpaceWebApp/src/app/services/backend.service.ts
+++ b/RevSpaceWebApp/src/app/services/backend.service.ts
@@ -1,0 +1,17 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class BackendService {
+
+  constructor() { }
+
+  /**
+   * @returns The URL of the backend api
+   */
+  public getBackendURL():string
+  {
+    return "http://localhost:8080";
+  }
+}

--- a/RevSpaceWebApp/src/app/services/login.service.ts
+++ b/RevSpaceWebApp/src/app/services/login.service.ts
@@ -3,6 +3,7 @@ import { Injectable } from '@angular/core';
 import { Credentials } from '../models/Credentials';
 import { LoginInfo } from '../models/LoginInfo';
 import { User } from '../models/User';
+import { BackendService } from './backend.service';
 
 @Injectable({
   providedIn: 'root'
@@ -10,6 +11,7 @@ import { User } from '../models/User';
 export class LoginService {
 
   constructor(
+    private backendService:BackendService,
     private http: HttpClient
   ) { }
 
@@ -28,7 +30,7 @@ export class LoginService {
     const myHeaders:HttpHeaders = new HttpHeaders({
       'Authorization': authToken
     });
-    const request = this.http.get<User>("http://localhost:8080/login", {headers:myHeaders});
+    const request = this.http.get<User>(this.backendService.getBackendURL() + "/login", {headers:myHeaders});
     const result = request.subscribe(
       (response)=>{
         this.loginInfo = new LoginInfo(response, authToken);

--- a/RevSpaceWebApp/src/app/services/post-http-service.service.ts
+++ b/RevSpaceWebApp/src/app/services/post-http-service.service.ts
@@ -1,13 +1,17 @@
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
+import { BackendService } from './backend.service';
 
 @Injectable({
   providedIn: 'root'
 })
 export class PostHttpServiceService {
 
-  constructor(private http: HttpClient) { }
+  constructor(
+    private backendService: BackendService,
+    private http: HttpClient
+    ) { }
 
   authToken: string = "Basic " + btoa("username1@email.com:Password1");
 
@@ -22,7 +26,7 @@ export class PostHttpServiceService {
 
     let authHeadersTen = new HttpHeaders({ 'Context-Type': 'application/json', 'Authorization': this.authToken, 'lastPostIdOnThePage': oldestIdString});
 
-    return this.http.get(`http://localhost:8080/posts`, {headers: authHeadersTen, observe:'response'});
+    return this.http.get(this.backendService.getBackendURL() + `/posts`, {headers: authHeadersTen, observe:'response'});
   }
 
   

--- a/RevSpaceWebApp/src/app/services/user.service.ts
+++ b/RevSpaceWebApp/src/app/services/user.service.ts
@@ -3,38 +3,42 @@ import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { User } from '../models/User';
 import { Credential } from '../models/Credential';
+import { BackendService } from './backend.service';
 
 @Injectable({
   providedIn: 'root'
 })
 export class UserService {
-  constructor(private http: HttpClient) { }
+  constructor(
+    private backendService:BackendService,
+    private http: HttpClient
+    ) { }
 
   private headers = new HttpHeaders({ 'Context-Type': 'application/json'});
 
   getUserById(id: number, myHeaders: HttpHeaders): Observable<User> {
-    return this.http.get<User>('http://localhost:8080/users/' + id, {headers:myHeaders});
+    return this.http.get<User>(this.backendService.getBackendURL() + '/users/' + id, {headers:myHeaders});
   }
 
   getUserByEmail(email: string): Observable<User> {
-    return this.http.get<User>('http://localhost:8080/users/email/' + email);
+    return this.http.get<User>(this.backendService.getBackendURL() + '/users/email/' + email);
   }
 
   getAllUsers(): Observable<User[]>{
-    return this.http.get<User[]>('http://localhost:8080/users');
+    return this.http.get<User[]>(this.backendService.getBackendURL() + '/users');
   }
 
   // A credential is created with a new User inside of it.
   addUser(credential: Credential): Observable<User> {
-    return this.http.post<User>('http://localhost:8080/users', credential, { headers: this.headers });
+    return this.http.post<User>(this.backendService.getBackendURL() + '/users', credential, { headers: this.headers });
   }
 
   deleteUser(id: number): Observable<User> {
-    return this.http.delete<User>('http://localhost:8080/users/' + id);
+    return this.http.delete<User>(this.backendService.getBackendURL() + '/users/' + id);
   }
 
   editUser(id: number, change: User, ): Observable<User> {
-    return this.http.put<User>('http://localhost:8080/users/' + id, change, { headers: this.headers });
+    return this.http.put<User>(this.backendService.getBackendURL() + 'users/' + id, change, { headers: this.headers });
   }
 
 }


### PR DESCRIPTION
and also refactor existing services to use this.

It's still currently hardcoded to localhost but it is now only hardcoded in a single place, making it easier to redirect to our EC2's url when that gets set up