### PR TITLE
Add environment variable for production backend url

### DIFF
--- a/RevSpaceWebApp/src/app/services/backend.service.ts
+++ b/RevSpaceWebApp/src/app/services/backend.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@angular/core';
+import { environment } from './../../environments/environment';
 
 @Injectable({
   providedIn: 'root'
@@ -12,6 +13,6 @@ export class BackendService {
    */
   public getBackendURL():string
   {
-    return "http://34.230.88.110:8081";
+    return environment.backendURL;
   }
 }

--- a/RevSpaceWebApp/src/app/services/backend.service.ts
+++ b/RevSpaceWebApp/src/app/services/backend.service.ts
@@ -12,6 +12,6 @@ export class BackendService {
    */
   public getBackendURL():string
   {
-    return "http://localhost:8080";
+    return "http://34.230.88.110:8081";
   }
 }

--- a/RevSpaceWebApp/src/environments/environment.prod.ts
+++ b/RevSpaceWebApp/src/environments/environment.prod.ts
@@ -1,3 +1,4 @@
 export const environment = {
+  backendURL: "http://34.230.88.110:8081",
   production: true
 };

--- a/RevSpaceWebApp/src/environments/environment.ts
+++ b/RevSpaceWebApp/src/environments/environment.ts
@@ -3,6 +3,7 @@
 // The list of file replacements can be found in `angular.json`.
 
 export const environment = {
+  backendURL: "http://localhost:8080",
   production: false
 };
 


### PR DESCRIPTION
This adds the backend url to the angular environment configurations; the development configuration continues to use localhost:8080 for the backend URL, while the production configuration now looks for the backend at the URL of the production server (the one hosted on jenkins).

Which configuration to be used is set with the `--configuration` flag when building or serving. By default, ng serve uses the development environment, while ng build uses the production environment.

```shell
ng serve # serve the test frontend, use localhost backend
ng serve --configuration=production # serve the test frontend but use the production server backend
ng build --configuration=development # build the production frontend, but it will look for the backend on localhost
ng build # build the production frontend, it will look for the production server's URL for the backend
```